### PR TITLE
Development

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -80,14 +80,29 @@ You may also want to adjust the **scheduler: fork** to **scheduler: sge** if you
 Step 3: Database Setup
 ----------------------
 
-The OrthoMCL also requires a SQL database such as [MySQL](http://www.mysql.com/) to be setup in order to load and process some of the results.  Both an account and a separate database need to be created specifically for OrthoMCL.
+The OrthoMCL also requires a [MySQL](http://www.mysql.com/) database to be setup in order to load and process some of the results.  An account needs to be created specifically for OrthoMCL. A special OrthoMCL configuration file needs to be generated with parameters and database connection information.  This can be generated automatically with the script **scripts/setup_database.pl**. There are two options for running this script as outlined below:
 
-Once the database is setup, a special OrthoMCL configuration file needs to be generated with parameters and database connection information.  This can be generated automatically with the script **scripts/setup_database.pl** as follows:
+Option 1: If you have a previously created database you can run the script with the option: --no-create-database
 
-	$ perl scripts/orthomcl-setup-database.pl --user orthomcl --password orthomcl --host localhost --database orthomcl > orthomcl.conf
-	Connecting to database orthomcl on host localhost with user orthomcl ...OK
+	$ perl scripts/orthomcl-setup-database.pl --user orthomcl --password orthomcl --host localhost --database orthomcl --outfile orthomcl.conf --no-create-database
+	Connecting to database orthmcl on host orthodb with user orthomcl ...
+	OK
+	Config file **orthomcl.conf** created.
+
+Option 2: 
+	If you want the script to create the datbase for you, run the script without --no-create-database. Prior to running the script the OrthoMCL account must be granted SELECT, INSERT, UPDATE, DELETE and CREATE permissions by logging into the MySQL server as root and executing the following command:
 	
-This will generate a file **orthomcl.conf** with database connection information and other parameters.  This file looks like:
+	mysql> GRANT SELECT, INSERT, UPDATE, DELETE, CREATE on *.* to orthomcl
+
+Once the user account is setup, the database can be generated with the same script that creates the configuration file as follows:
+
+	$ perl scripts/orthomcl-setup-database.pl --user orthomcl --password orthomcl --host localhost --database orthomcl --outfile orthomcl.conf
+	Connecting to mysql and creating database **orthmcldb** on host orthodb with user orthomcl ...
+	OK
+	database orthmcl created ...OK
+	Config file **orthomcl.conf** created.
+	
+Either option will generate a file **orthomcl.conf** with database connection information and other parameters.  This file looks like:
 
 ```
 coOrthologTable=CoOrtholog

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,9 +90,9 @@ Option 1: If you have a previously created database you can run the script with 
 	Config file **orthomcl.conf** created.
 
 Option 2: 
-	If you want the script to create the datbase for you, run the script without --no-create-database. Prior to running the script the OrthoMCL account must be granted SELECT, INSERT, UPDATE, DELETE and CREATE permissions by logging into the MySQL server as root and executing the following command:
+	If you want the script to create the datbase for you, run the script without --no-create-database. Prior to running the script the OrthoMCL account must be granted SELECT, INSERT, UPDATE, DELETE, CREATE, CREATE VIEW, INDEX and DROP permissions by logging into the MySQL server as root and executing the following command:
 	
-	mysql> GRANT SELECT, INSERT, UPDATE, DELETE, CREATE on *.* to orthomcl
+	mysql> GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, CREATE VIEW, INDEX, DROP on *.* to orthomcl;
 
 Once the user account is setup, the database can be generated with the same script that creates the configuration file as follows:
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Usage: orthomcl-pipeline -i [input dir] -o [output dir] -m [orthmcl config] [Opt
 	--print-orthomcl-config:  Prints example orthomcl config file.
 	--yes: Automatically answers yes to every question (could overwrite/delete old data).
 	--scheduler: Defined scheduler (sge or fork).
+	--no-cleanup: Does not remove temporary tables from database.
 	-h|--help:  Show help.
 
 	Examples:
@@ -66,4 +67,8 @@ Usage: orthomcl-pipeline -i [input dir] -o [output dir] -m [orthmcl config] [Opt
 	orthomcl-pipeline -i input/ -o output/ -m orthomcl.confg --compliant
 		Runs orthmcl with the given input/output/config files.
 		Skips the orthomclAdjustFasta stage on input files.
+
+	orthomcl-pipeline -i input/ -o output/ -m orthomcl.confg --no-cleanup
+		Runs orthmcl with the given input/output/config files.
+		Does not cleanup temporary tables.
 ```

--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@ Usage
 
 The brief overview of running the OrthoMCL pipeline is as follows:
 
-1. Setup MySQL database for OrthoMCL.  Please see the [OrthoMCL Documentation](http://orthomcl.org/common/downloads/software/v2.0/UserGuide.txt) for more information.
-
-2. Run the following command to verify the database setup and generate an OrthoMCL configuration file.
+1. Run the following command to setup the database, verify the setup and generate an OrthoMCL configuration file.
 
    ```bash
-   perl scripts/orthomcl-setup-database.pl --user orthomcl_database_user --password orthomcl_database_password --host orthomcl_database_host --database orthomcl_database > orthomcl.conf
+   perl scripts/orthomcl-setup-database.pl --user orthomcl_database_user --password orthomcl_database_password --host orthomcl_database_host --database orthomcl_database --outfile configure_outfile.conf [--no-create-database]
    ```
 
-3. Run the following command to start OrthoMCL.
+2. Run the following command to start OrthoMCL.
 
    ```bash
    perl scripts/orthomcl-pipeline.pl -i input/ -o output/ -m orthomcl.conf --nocompliant

--- a/scripts/orthomcl-pipeline.pl
+++ b/scripts/orthomcl-pipeline.pl
@@ -60,6 +60,7 @@ sub usage
 	--print-orthomcl-config:  Prints example orthomcl config file.
 	--yes: Automatically answers yes to every question (could overwrite/delete old data).
 	--scheduler: Defined scheduler (sge or fork).
+	--no-cleanup: Does not remove temporary tables from database.
 	-h|--help:  Show help.
 
 	Examples:
@@ -80,6 +81,10 @@ sub usage
 	orthomcl-pipeline -i input/ -o output/ -m orthomcl.confg --compliant
 		Runs orthmcl with the given input/output/config files.
 		Skips the orthomclAdjustFasta stage on input files.
+
+	orthomcl-pipeline -i input/ -o output/ -m orthomcl.confg --no-cleanup
+		Runs orthmcl with the given input/output/config files.
+		Does not cleanup temporary tables.
 
 	Version:
 	Git: https://github.com/apetkau/orthomcl-pipeline
@@ -603,7 +608,7 @@ sub ortho_load
 
 sub ortho_pairs
 {
-	my ($stage_num, $ortho_config, $log_dir) = @_;
+	my ($stage_num, $ortho_config, $log_dir, $cleanup) = @_;
 
 	my $ortho_log = "$log_dir/$stage_num.orthomclPairs.log";
 
@@ -616,7 +621,7 @@ sub ortho_pairs
 
 	my $abs_ortho_config = File::Spec->rel2abs($ortho_config);
 
-	my $param_keys = ["$abs_ortho_config", "$ortho_log", "cleanup=yes"];
+	my $param_keys = ["$abs_ortho_config", "$ortho_log", "cleanup=$cleanup"];
 	my $param_values = [undef, undef, undef];
 
 	$job_runner->submit_job($pairsbin, $param_keys, $param_values, "$ortho_log.stdout", "$ortho_log.stderr");
@@ -809,6 +814,8 @@ my $main_config;
 my $compliant = 1;
 my $print_config;
 my $print_orthomcl_config;
+my $no_cleanup;
+my $cleanup = 'yes';
 my $help;
 my $yes_opt;
 my $scheduler;
@@ -824,6 +831,7 @@ if (!GetOptions(
 	'compliant!' => \$compliant,
 	'print-config' => \$print_config,
 	'print-orthomcl-config' => \$print_orthomcl_config,
+	'no-cleanup' => \$no_cleanup,
 	'h|help' => \$help))
 {
 	die "$!".usage;
@@ -865,6 +873,11 @@ if (defined $print_orthomcl_config and $print_orthomcl_config)
 	close($ch);
 	exit 0;
 }
+
+if (defined $no_cleanup)
+{
+	$cleanup = 'no';
+} 
 
 
 die "Error: no input-dir defined\n".usage if (not defined $input_dir);
@@ -974,7 +987,7 @@ format_database(7, $blast_dir, $log_dir);
 perform_blast(8, $blast_dir, $blast_results_dir, $split_number, $blast_log_dir);
 parseblast(9, $blast_results_dir, $blast_load_dir, $orthomcl_config, $compliant_dir, $log_dir);
 ortho_load(10, $orthomcl_config, $blast_load_dir, $log_dir);
-ortho_pairs(11, $orthomcl_config, $log_dir);
+ortho_pairs(11, $orthomcl_config, $log_dir, $cleanup);
 ortho_dump_pairs(12, $orthomcl_config, $pairs_dir, $log_dir);
 run_mcl(13, $pairs_dir, $log_dir);
 mcl_to_groups(14, $pairs_dir, $groups_dir, $log_dir);

--- a/scripts/orthomcl-setup-database.pl
+++ b/scripts/orthomcl-setup-database.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # setup_database.pl
-# Purpose: used to check for and setup a configuration file for
+# Purpose: used to create and setup a configuration file for
 # the OrthoMCL database connection.
 
 use warnings;
@@ -16,15 +16,20 @@ my $script_dir = $FindBin::Bin;
 
 my $default_config = "$script_dir/../etc/orthomcl.config.example";
 
-my $usage = "Usage: ".basename($0)." --user [user] --password [password] --host [host] --database [database]\n".
-"Checks for a database connection and generates an orthomcl config file with the given parameters\n";
+my $usage = "Usage: ".basename($0)."\n --user [user] --password [password] --host [host] --database [database] --outfile [outfile] --no-create-database\n".
+"\nChecks for a database connection, creates a database (when not suppressed) and generates an orthomcl config file with the given parameters.\n".
+"Note this script requires a MySQL database.\n".
+"The database name provided does not need to exist and will be created unless option --no-create-database is used.\n".
+"Ensure the user has permissions to create, modify and delete databases.\n\n";
 
-my ($user,$password,$host, $database);
+my ($user,$password,$host, $database, $outfile, $no_create_db );
 if (not GetOptions(
 	'user=s' => \$user,
 	'password=s' => \$password,
 	'host=s' => \$host,
-	'database=s' => \$database))
+	'database=s' => \$database,
+	'no-create-database' => \$no_create_db,
+	'outfile=s' => \$outfile))
 {
 	die "$!\n".$usage;
 }
@@ -32,24 +37,82 @@ if (not GetOptions(
 if (not (defined $user and
 	 defined $password and
 	 defined $host and
-	 defined $database))
+	 defined $database and
+	 defined $outfile))
 {
 	die "missing database information\n".$usage;
 }
 
 my $parameters = parse_config($default_config);
+my $dbh;
 
-print STDERR "Connecting to database $database on host $host with user $user ...";
-my $db_connect_string = "dbi:mysql:$database:$host:mysql_local_infile=1";
-my $dbh = DBI->connect($db_connect_string,$user,$password, {RaiseError => 1, AutoCommit => 0});
-if (not defined $dbh)
+# Check if config file already exists.
+if (-e $outfile)
 {
-	die "error connecting to database";
-}
+    print STDERR "Warning: file $outfile already exists ... overwrite? (Y/N) ";
+    my $choice = <STDIN>;
+    chomp $choice;
+    if ("yes" eq lc($choice) or "y" eq lc($choice))
+    {
+       print STDERR "\nConfig file, $outfile will be overwritten\n";
+    }
+    else
+    {
+        die "\nConfig file will not be overwritten, please choose a new name and try again!"; 
+    }
+} 
+
+if(defined $no_create_db)
+{
+	# User already has a database to use
+	# Check that can connect to database
+	print STDERR "Connecting to database $database on host $host with user $user ...\n";
+	my $db_connect = "dbi:mysql:$database:$host:mysql_local_infile=1";
+	$dbh = DBI->connect($db_connect,$user,$password, {RaiseError => 0, AutoCommit => 0});
+	if (not defined $dbh)
+	{
+		# Not able to connect to previously created database
+		die "error connecting to database (please ensure database exists and try again)";
+	}
+	else
+	{
+		print STDERR "OK\n";
+		close_db();
+	}
+} 
 else
 {
-	print STDERR "OK\n";
+	# User wants to create a new database
+	# Connect to server and create new database
+	print STDERR "Connecting to mysql and creating database $database on host $host with user $user ...\n";
+	my $db_connect_create = "dbi:mysql:mysql:$host:mysql_local_infile=1";
+	$dbh = DBI->connect($db_connect_create,$user,$password, {RaiseError => 0, AutoCommit => 0});
+	if (not defined $dbh)
+	{
+		# not able to connect to my sql database
+		die "error connecting to database";
+	}
+	else
+	{
+		print STDERR "OK\n";
+	}
+
+	my $rc = $dbh->do("SHOW DATABASES LIKE '$database'");
+	if ($rc == 1)
+	{
+		close_db();
+	    die "Database $database already exists, please choose a new database name";
+	}
+	else
+	{
+	    $dbh->do("CREATE DATABASE $database")
+	    or die "\nCouldn't create database $database";
+	    print STDERR "database $database created ...OK\n";
+	    close_db();
+	}
 }
+# once database is created, create the db_connect_string to use in config file
+my $db_connect_string = "dbi:mysql:$database:$host:mysql_local_infile=1";
 
 $parameters->{'dbConnectString'} = $db_connect_string;
 $parameters->{'dbLogin'} = $user;
@@ -61,11 +124,16 @@ sub write_config
 {
 	my ($parameters) = @_;
 
+	unless(open FILE,'>',$outfile){
+		die "Unable to create $outfile\n"
+	}
 	foreach my $key (sort {$a cmp $b} keys %$parameters)
 	{
 		my $value = $parameters->{$key};
-		print "$key=$value\n";
+		print FILE "$key=$value\n";
 	}
+    print STDERR "Config file $outfile created.\n";
+	close FILE;
 }
 
 sub parse_config
@@ -92,4 +160,9 @@ sub parse_config
 	close($fh);
 
 	return \%parameters;
+}
+
+sub close_db
+{
+    $dbh->disconnect();
 }


### PR DESCRIPTION
Updating master with improvements to:

* Construct new orthomcl databases using the `orthomcl-pipeline-setup.pl` script.  Can use `--no-create-database` if the database already exists (previous behaviour).
* Added option to `orthomcl-pipeline.pl` to disable cleanup of SQL tables following an analysis
* Updating installation and usage instructions.